### PR TITLE
fix: adjust images position in a quoted toot

### DIFF
--- a/fedibird.user.styl
+++ b/fedibird.user.styl
@@ -21,7 +21,7 @@ fedibird.com のモダンテーマ（ダーク・ライト共通）のデザイ�
 }
 
 @-moz-document regexp("https://fedibird.com/web/(?!statuses).*$") {
-/* 引用に含まれる画像の位置 */
+/* 引用に含まれる画像・動画の位置 */
 div.video-player.inline,
 div.media-gallery:nth-child(3) {
   left: 15%;
@@ -38,9 +38,15 @@ div.media-gallery:nth-child(3) {
   padding-top: 2.5px;
   padding-left: 2.5px;
 }
-
 .quote-status > a:nth-child(1) > span:nth-child(2) > bdi:nth-child(1) {
   padding-left: 0.25rem;
+}
+
+/* 引用に含まれる画像・動画の位置 */
+div.video-player.inline,
+div.media-gallery:nth-child(3) {
+  left: 15%;
+  width: 90% !important;
 }
 
 }


### PR DESCRIPTION
URLが `/web/statuses/...` の場合、まだ画像の大きすぎる状態で表示されるので修正します。

At URL path like `/web/statuses/...` , images position is still shown too large.  so, fix. 

### before

![スクリーンショット 2023-02-20 215017](https://user-images.githubusercontent.com/1286319/220113665-96f57e23-23fe-4a65-9af1-49ec931769c1.png)

### after

![スクリーンショット 2023-02-20 215344](https://user-images.githubusercontent.com/1286319/220114399-bbe7869b-a545-42d3-bdab-e36eb777abb5.png)
