### PR TITLE
fix: djust images position in a none quoted toot at /web/statuses

### DIFF
--- a/fedibird.user.styl
+++ b/fedibird.user.styl
@@ -22,8 +22,8 @@ fedibird.com のモダンテーマ（ダーク・ライト共通）のデザイ�
 
 @-moz-document regexp("https://fedibird.com/web/(?!statuses).*$") {
 /* 引用に含まれる画像・動画の位置 */
-div.video-player.inline,
-div.media-gallery:nth-child(3) {
+div.quote-status.status-public > div.video-player.inline,
+div.quote-status.status-public > div.media-gallery {
   left: 15%;
   width: 90% !important;
   padding: 1rem;
@@ -43,8 +43,8 @@ div.media-gallery:nth-child(3) {
 }
 
 /* 引用に含まれる画像・動画の位置 */
-div.video-player.inline,
-div.media-gallery:nth-child(3) {
+div.quote-status.status-public > div.video-player.inline,
+div.quote-status.status-public > div.media-gallery {
   left: 15%;
   width: 90% !important;
 }


### PR DESCRIPTION
#1  の変更により、今度はクオートしていない部分の画像の位置がずれてしまうようになりました。  `class=quote-status` の子の要素にのみ適用されるような修正を加えます。
  
the changes in #1, now cause images in unquoted toot to be misaligned. so fix.


### before 

![image](https://user-images.githubusercontent.com/1286319/220120548-4392d2d4-0a9f-4a3c-9163-2fb612df3fc9.png)


### after

![image](https://user-images.githubusercontent.com/1286319/220120632-ef328607-952f-44e1-8da1-5998d79efc50.png)
